### PR TITLE
Track notifications by ID

### DIFF
--- a/src/database/models/account_notification.ts
+++ b/src/database/models/account_notification.ts
@@ -41,6 +41,21 @@ AccountNotification.init(
       allowNull: false,
       defaultValue: false
     },
+    lastReplyId: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      defaultValue: null,
+    },
+    lastMentionId: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      defaultValue: null,
+    },
+    lastMessageId: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      defaultValue: null,
+    },
   },
   { sequelize }
 );

--- a/src/notifications/service/notification_service.ts
+++ b/src/notifications/service/notification_service.ts
@@ -36,11 +36,11 @@ async function checkUnreadReplies(
     return reply.comment_reply.id > lastReplyId;
   });
 
-  const firstCheck = lastReplyId == null;
+  const isFirstCheck = lastReplyId == null;
 
   lastReplyId = replies[0]?.comment_reply?.id || lastReplyId || 0;
 
-  if (firstCheck) {
+  if (isFirstCheck) {
     // The first time we check for a given account we don't want to send all notifications from the past.
     // So just update the ID and let the NEXT check send NEW notifications.
     return lastReplyId;
@@ -95,11 +95,11 @@ async function checkUnreadMentions(
     return mention.person_mention.id > lastMentionId;
   });
 
-  const firstCheck = lastMentionId == null;
+  const isFirstCheck = lastMentionId == null;
 
   lastMentionId = mentions[0]?.person_mention?.id || lastMentionId || 0;
 
-  if (firstCheck) {
+  if (isFirstCheck) {
     // The first time we check for a given account we don't want to send all notifications from the past.
     // So just update the ID and let the NEXT check send NEW notifications.
     return lastMentionId;
@@ -152,11 +152,11 @@ async function checkUnreadMessages(
     return privateMessage.private_message.id > lastMessageId;
   });
 
-  const firstCheck = lastMessageId == null;
+  const isFirstCheck = lastMessageId == null;
 
   lastMessageId = privateMessages[0]?.private_message?.id || lastMessageId || 0;
 
-  if (firstCheck) {
+  if (isFirstCheck) {
     // The first time we check for a given account we don't want to send all notifications from the past.
     // So just update the ID and let the NEXT check send NEW notifications.
     return lastMessageId;


### PR DESCRIPTION
This PR updates the notification server to use IDs rather than timestamps when determining which notifications to process. This relies on the fact that local IDs are always incrementing. This should solve at least two problems with missing notifications.
* Notifications may be missing due to a race condition, where a notification arrives after we have done the processing but before we have updated the `timestamp`.
* Notifications may be missing due to federation issues, where a notification with an old publication date does not get federated until sometime later (fortunately, in this case, the ID is still incremented on the local instance).

Eventually we should probably make a similar change in Thunder for local notifications, but I think it's less of an issue (seems to be more related to the federation case than the race condition case).